### PR TITLE
Fix compatibility by class_alias Fix #5

### DIFF
--- a/classes/external/deletemodel_external.php
+++ b/classes/external/deletemodel_external.php
@@ -38,6 +38,7 @@ use external_value;
 use invalid_parameter_exception;
 use mod_certifygen\persistents\certifygen_model;
 use moodle_exception;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 class deletemodel_external extends external_api {
     /**

--- a/classes/external/deleteteacherrequest_external.php
+++ b/classes/external/deleteteacherrequest_external.php
@@ -41,6 +41,7 @@ use mod_certifygen\interfaces\ICertificateValidation;
 use mod_certifygen\persistents\certifygen_model;
 use mod_certifygen\persistents\certifygen_validations;
 use moodle_exception;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 class deleteteacherrequest_external extends external_api {
     /**

--- a/classes/external/downloadcertificate_external.php
+++ b/classes/external/downloadcertificate_external.php
@@ -49,6 +49,7 @@ use mod_certifygen\persistents\certifygen_model;
 use mod_certifygen\persistents\certifygen_validations;
 use mod_certifygen\template;
 use moodle_exception;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 class downloadcertificate_external extends external_api {
     /**

--- a/classes/external/downloadteachercertificate_external.php
+++ b/classes/external/downloadteachercertificate_external.php
@@ -44,6 +44,7 @@ use mod_certifygen\interfaces\ICertificateValidation;
 use mod_certifygen\persistents\certifygen_model;
 use mod_certifygen\persistents\certifygen_validations;
 use moodle_url;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 class downloadteachercertificate_external extends external_api {
     /**

--- a/classes/external/emitcertificate_external.php
+++ b/classes/external/emitcertificate_external.php
@@ -48,6 +48,7 @@ use mod_certifygen\interfaces\ICertificateValidation;
 use mod_certifygen\persistents\certifygen_model;
 use mod_certifygen\persistents\certifygen_validations;
 use moodle_exception;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 class emitcertificate_external extends external_api {
     /**

--- a/classes/external/emitteacherrequest_external.php
+++ b/classes/external/emitteacherrequest_external.php
@@ -44,6 +44,7 @@ use mod_certifygen\interfaces\ICertificateReport;
 use mod_certifygen\interfaces\ICertificateValidation;
 use mod_certifygen\persistents\certifygen_model;
 use mod_certifygen\persistents\certifygen_validations;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 class emitteacherrequest_external extends external_api {
     /**

--- a/classes/external/getJsonStudentCourseCompleted_external.php
+++ b/classes/external/getJsonStudentCourseCompleted_external.php
@@ -36,6 +36,7 @@ use external_api;
 use external_function_parameters;
 use external_single_structure;
 use external_value;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 class getJsonStudentCourseCompleted_external extends external_api {
     /**

--- a/classes/external/getPdfStudentCourseCompleted_external.php
+++ b/classes/external/getPdfStudentCourseCompleted_external.php
@@ -36,6 +36,7 @@ use external_api;
 use external_function_parameters;
 use external_single_structure;
 use external_value;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 class getPdfStudentCourseCompleted_external extends external_api {
     /**

--- a/classes/external/get_courses_as_student_external.php
+++ b/classes/external/get_courses_as_student_external.php
@@ -41,6 +41,7 @@ use external_value;
 use mod_certifygen\persistents\certifygen;
 use mod_certifygen\persistents\certifygen_context;
 use mod_certifygen\persistents\certifygen_model;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 global $CFG;
 require_once($CFG->dirroot.'/user/lib.php');

--- a/classes/external/get_courses_as_teacher_external.php
+++ b/classes/external/get_courses_as_teacher_external.php
@@ -40,6 +40,7 @@ use external_multiple_structure;
 use external_value;
 use mod_certifygen\persistents\certifygen_context;
 use mod_certifygen\persistents\certifygen_model;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 global $CFG;
 require_once($CFG->dirroot.'/user/lib.php');

--- a/classes/external/get_id_instance_certificate_external.php
+++ b/classes/external/get_id_instance_certificate_external.php
@@ -41,6 +41,7 @@ use mod_certifygen\persistents\certifygen;
 use mod_certifygen\persistents\certifygen_context;
 use mod_certifygen\persistents\certifygen_model;
 use certifygenfilter;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 global $CFG;
 require_once($CFG->dirroot.'/user/lib.php');

--- a/classes/external/get_json_certificate_external.php
+++ b/classes/external/get_json_certificate_external.php
@@ -40,6 +40,7 @@ use mod_certifygen\persistents\certifygen;
 use mod_certifygen\persistents\certifygen_model;
 use mod_certifygen\persistents\certifygen_validations;
 use certifygenfilter;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 global $CFG;
 require_once($CFG->dirroot.'/user/lib.php');

--- a/classes/external/get_json_teacher_certificate_external.php
+++ b/classes/external/get_json_teacher_certificate_external.php
@@ -37,6 +37,7 @@ use external_function_parameters;
 use external_single_structure;
 use external_value;
 use certifygenfilter;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 global $CFG;
 require_once($CFG->dirroot.'/mod/certifygen/lib.php');

--- a/classes/external/get_pdf_certificate_external.php
+++ b/classes/external/get_pdf_certificate_external.php
@@ -39,6 +39,7 @@ use external_value;
 use mod_certifygen\persistents\certifygen;
 use mod_certifygen\persistents\certifygen_model;
 use mod_certifygen\persistents\certifygen_validations;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 global $CFG;
 require_once($CFG->dirroot.'/user/lib.php');

--- a/classes/external/get_pdf_teacher_certificate_external.php
+++ b/classes/external/get_pdf_teacher_certificate_external.php
@@ -40,6 +40,7 @@ use mod_certifygen\interfaces\ICertificateReport;
 use mod_certifygen\interfaces\ICertificateValidation;
 use mod_certifygen\persistents\certifygen_model;
 use mod_certifygen\persistents\certifygen_validations;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 global $CFG;
 require_once($CFG->dirroot.'/user/lib.php');

--- a/classes/external/getcoursesnames_external.php
+++ b/classes/external/getcoursesnames_external.php
@@ -40,6 +40,7 @@ use external_value;
 use mod_certifygen\persistents\certifygen;
 use mod_certifygen\persistents\certifygen_context;
 use mod_certifygen\persistents\certifygen_model;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 global $CFG;
 require_once($CFG->dirroot.'/user/lib.php');

--- a/classes/external/getmodellisttable_external.php
+++ b/classes/external/getmodellisttable_external.php
@@ -40,6 +40,7 @@ use moodle_url;
 use external_function_parameters;
 use external_single_structure;
 use external_value;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 class getmodellisttable_external extends external_api {
     /**
      * Describes the external function parameters.

--- a/classes/external/getmycertificatedata_external.php
+++ b/classes/external/getmycertificatedata_external.php
@@ -49,6 +49,7 @@ use external_single_structure;
 use external_value;
 use moodle_exception;
 use moodle_url;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 class getmycertificatedata_external extends external_api {
     /**

--- a/classes/external/getteacherrequestviewdata_external.php
+++ b/classes/external/getteacherrequestviewdata_external.php
@@ -40,6 +40,7 @@ use external_function_parameters;
 use external_single_structure;
 use external_value;
 use moodle_exception;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 class getteacherrequestviewdata_external extends external_api {
     /**

--- a/classes/external/notify_certification_external.php
+++ b/classes/external/notify_certification_external.php
@@ -36,6 +36,7 @@ use external_api;
 use external_function_parameters;
 use external_single_structure;
 use external_value;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 class notify_certification_external extends external_api {
     /**

--- a/classes/external/reemitcertificate_external.php
+++ b/classes/external/reemitcertificate_external.php
@@ -45,6 +45,7 @@ use mod_certifygen\interfaces\ICertificateValidation;
 use mod_certifygen\persistents\certifygen;
 use mod_certifygen\persistents\certifygen_model;
 use mod_certifygen\persistents\certifygen_validations;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 class reemitcertificate_external extends external_api {
     /**

--- a/classes/external/reemitteacherrequest_external.php
+++ b/classes/external/reemitteacherrequest_external.php
@@ -44,6 +44,7 @@ use mod_certifygen\interfaces\ICertificateReport;
 use mod_certifygen\interfaces\ICertificateValidation;
 use mod_certifygen\persistents\certifygen_model;
 use mod_certifygen\persistents\certifygen_validations;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 class reemitteacherrequest_external extends external_api {
     /**

--- a/classes/external/revokecertificate_external.php
+++ b/classes/external/revokecertificate_external.php
@@ -48,6 +48,7 @@ use mod_certifygen\interfaces\ICertificateValidation;
 use mod_certifygen\persistents\certifygen_model;
 use mod_certifygen\persistents\certifygen_validations;
 use moodle_exception;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 class revokecertificate_external extends external_api {
     /**

--- a/classes/external/searchcategory_external.php
+++ b/classes/external/searchcategory_external.php
@@ -32,6 +32,9 @@ use external_value;
 use invalid_parameter_exception;
 use restricted_context_exception;
 
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
+
+
 /**
  * @package    mod_certifygen
  * * @copyright  2024 Proyecto UNIMOODLE

--- a/classes/external/searchcourse_external.php
+++ b/classes/external/searchcourse_external.php
@@ -31,6 +31,7 @@ use external_single_structure;
 use external_value;
 use invalid_parameter_exception;
 use restricted_context_exception;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 /**
  * @package    mod_certifygen

--- a/classes/external/searchmycourses_external.php
+++ b/classes/external/searchmycourses_external.php
@@ -31,6 +31,7 @@ use external_single_structure;
 use external_value;
 use invalid_parameter_exception;
 use restricted_context_exception;
+require_once($CFG->dirroot . '/mod/certifygen/externalcompatibility.php');
 
 /**
  * @package    mod_certifygen

--- a/externalcompatibility.php
+++ b/externalcompatibility.php
@@ -1,0 +1,10 @@
+<?php
+// After Moodle 4.2 external classes were moved.
+if ($CFG->version >= 2023042400) {
+    class_alias('core_external\external_api', 'external_api');
+    class_alias('core_external\external_description', 'external_description');
+    class_alias('core_external\external_function_parameters', 'external_function_parameters');
+    class_alias('core_external\external_multiple_structure', 'external_multiple_structure');
+    class_alias('core_external\external_single_structure', 'external_single_structure');
+    class_alias('core_external\external_value', 'external_value');
+}


### PR DESCRIPTION
Fix #5 both in Moodle 4.1 and 4.2+

Define alias de las clases para que el código funcione en ambas familias.